### PR TITLE
Write generated Rust code to the source tree; apply fixups

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,10 +29,15 @@ jobs:
         with:
           toolchain: stable
           default: true
+          components: rustfmt
       - name: cargo build
         run: cargo build
       - name: cargo test
         run: cargo test
+      - name: cargo build (regenerate)
+        run: cargo build --features regenerate
+      - name: cargo test (regenerate)
+        run: cargo test --features regenerate
   tests-msrv:
     name: "Tests, minimum supported toolchain"
     runs-on: ubuntu-latest
@@ -44,10 +49,15 @@ jobs:
         with:
           toolchain: ${{ env['ACTIONS_MSRV_TOOLCHAIN']  }}
           default: true
+          components: rustfmt
       - name: cargo build
         run: cargo build
       - name: cargo test
         run: cargo test
+      - name: cargo build (regenerate)
+        run: cargo build --features regenerate
+      - name: cargo test (regenerate)
+        run: cargo test --features regenerate
   lints:
     name: "Lints, pinned toolchain"
     runs-on: ubuntu-latest
@@ -64,8 +74,12 @@ jobs:
         run: cargo fmt -- --check -l
       - name: cargo clippy (warnings)
         run: cargo clippy -- -D warnings
+      - name: cargo clippy (warnings, regenerate)
+        run: cargo clippy --features regenerate -- -D warnings
       - name: cargo build
         run: cargo build
+      - name: cargo build (regenerate)
+        run: cargo build --features regenerate
   tests-other-channels:
     name: "Tests, unstable toolchain"
     runs-on: ubuntu-latest
@@ -83,7 +97,12 @@ jobs:
         with:
           toolchain: ${{ matrix.channel }}
           default: true
+          components: rustfmt
       - name: cargo build
         run: cargo build
       - name: cargo test
         run: cargo test
+      - name: cargo build (regenerate)
+        run: cargo build --features regenerate
+      - name: cargo test (regenerate)
+        run: cargo test --features regenerate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,12 @@ post-release-commit-message = "cargo: development version bump"
 tag-message = "ignition-config v{{version}}"
 
 [dependencies]
-schemafy = "0.5.2"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+
+[build-dependencies]
+anyhow = "1.0"
+schemafy_lib = { git = "https://github.com/Marwes/schemafy", optional = true }
+tempfile = { version = "3.2.0", optional = true }
+
+[features]
+regenerate = ["schemafy_lib", "tempfile"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,11 @@ serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
 anyhow = "1.0"
+proc-macro2 = { version = "1.0", optional = true }
+quote = { version = "1.0", optional = true }
 schemafy_lib = { git = "https://github.com/Marwes/schemafy", optional = true }
+syn = { version = "1.0", features = ["full", "parsing", "visit-mut"], optional = true }
 tempfile = { version = "3.2.0", optional = true }
 
 [features]
-regenerate = ["schemafy_lib", "tempfile"]
+regenerate = ["proc-macro2", "quote", "schemafy_lib", "syn", "tempfile"]

--- a/build.rs
+++ b/build.rs
@@ -105,6 +105,32 @@ mod regenerate {
             }
             visit_mut::visit_field_mut(self, node);
         }
+
+        fn visit_item_struct_mut(&mut self, node: &mut syn::ItemStruct) {
+            // mangle struct identifier in declaration
+            // https://github.com/Marwes/schemafy/pull/49
+            let name = node.ident.to_string();
+            let new_name = name
+                .replace("ItemGroup", "Group")
+                .replace("GroupUser", "User");
+            if new_name != name {
+                node.ident = Ident::new(&new_name, Span::call_site())
+            }
+            visit_mut::visit_item_struct_mut(self, node);
+        }
+
+        fn visit_path_segment_mut(&mut self, node: &mut syn::PathSegment) {
+            // mangle struct identifier in field type
+            // https://github.com/Marwes/schemafy/pull/49
+            let name = node.ident.to_string();
+            let new_name = name
+                .replace("ItemGroup", "Group")
+                .replace("GroupUser", "User");
+            if new_name != name {
+                node.ident = Ident::new(&new_name, Span::call_site())
+            }
+            visit_mut::visit_path_segment_mut(self, node);
+        }
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,58 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "regenerate")]
+mod regenerate {
+    use std::fs::read_dir;
+    use std::path::Path;
+
+    use anyhow::{anyhow, Result};
+    use schemafy_lib::Generator;
+    use tempfile::NamedTempFile;
+
+    pub fn regenerate() -> Result<()> {
+        for entry in read_dir("src")? {
+            let entry = entry?;
+            let schema_path = entry.path().join("ignition.json");
+            if schema_path.exists() {
+                // ignore OUT_DIR and illicitly write back to the source tree
+                // https://doc.rust-lang.org/cargo/reference/build-script-examples.html#code-generation
+                regenerate_one(&schema_path, &entry.path().join("schema.rs"))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn regenerate_one(schema_path: &Path, rust_path: &Path) -> Result<()> {
+        let output_file = NamedTempFile::new_in(rust_path.parent().unwrap())?;
+        Generator::builder()
+            .with_root_name_str("Config")
+            .with_input_file(&schema_path)
+            .build()
+            .generate_to_file(
+                &output_file
+                    .path()
+                    .to_str()
+                    .ok_or_else(|| anyhow!("couldn't convert output path"))?,
+            )?;
+        output_file.persist(rust_path)?;
+        Ok(())
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    #[cfg(feature = "regenerate")]
+    regenerate::regenerate()?;
+    Ok(())
+}

--- a/build.rs
+++ b/build.rs
@@ -146,6 +146,28 @@ mod regenerate {
             }
             visit_mut::visit_path_segment_mut(self, node);
         }
+
+        fn visit_file_mut(&mut self, node: &mut syn::File) {
+            // drop definitions for now-unused user/group structs
+            // https://github.com/Marwes/schemafy/issues/50
+            visit_mut::visit_file_mut(self, node);
+            node.items = node
+                .items
+                .drain(..)
+                .filter(|item| match item {
+                    syn::Item::Struct(s) => !matches!(
+                        s.ident.to_string().as_str(),
+                        "DirectoryGroup"
+                            | "DirectoryUser"
+                            | "FileGroup"
+                            | "FileUser"
+                            | "LinkGroup"
+                            | "LinkUser"
+                    ),
+                    _ => true,
+                })
+                .collect();
+        }
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -121,11 +121,26 @@ mod regenerate {
 
         fn visit_path_segment_mut(&mut self, node: &mut syn::PathSegment) {
             // mangle struct identifier in field type
+
             // https://github.com/Marwes/schemafy/pull/49
             let name = node.ident.to_string();
-            let new_name = name
+            let mut new_name = name
                 .replace("ItemGroup", "Group")
                 .replace("GroupUser", "User");
+
+            // coalesce node user/group structs
+            // https://github.com/Marwes/schemafy/issues/50
+            new_name = match new_name.as_str() {
+                "DirectoryGroup" => "NodeGroup",
+                "DirectoryUser" => "NodeUser",
+                "FileGroup" => "NodeGroup",
+                "FileUser" => "NodeUser",
+                "LinkGroup" => "NodeGroup",
+                "LinkUser" => "NodeUser",
+                _ => &new_name,
+            }
+            .to_string();
+
             if new_name != name {
                 node.ident = Ident::new(&new_name, Span::call_site())
             }

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,9 @@
 # Development documentation
 
+## Regenerating `schema.rs`
+
+Run `cargo build --features regenerate`.
+
 ## Release process
 
 Create a new [release checklist](https://github.com/coreos/ignition-config-rs/issues/new?labels=release&template=release-checklist.md) and follow the steps there.

--- a/src/v3_0/mod.rs
+++ b/src/v3_0/mod.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use schemafy::schemafy;
 use serde::{Deserialize, Serialize};
 
-schemafy!(
-    root: Config
-    "src/v3_0/ignition.json"
-);
+include!("schema.rs");

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -131,14 +131,14 @@ pub struct DirectoryUser {
 #[serde(rename = "directory")]
 pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<DirectoryGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<DirectoryUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
@@ -172,14 +172,14 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contents: Option<FileContents>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<FileGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<FileUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "file-contents")]
@@ -227,7 +227,7 @@ pub struct LinkUser {
 #[serde(rename = "link")]
 pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<LinkGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub hard: Option<bool>,
     #[serde(default)]
@@ -235,7 +235,7 @@ pub struct Link {
     pub path: String,
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<LinkUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 pub struct NodeGroup {

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -113,20 +113,6 @@ pub struct Passwd {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub users: Option<Vec<User>>,
 }
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "directory")]
 pub struct Directory {
@@ -149,20 +135,6 @@ pub struct Disk {
     #[serde(default)]
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "file")]
@@ -208,20 +180,6 @@ pub struct Filesystem {
     #[serde(default)]
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "link")]

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -121,7 +121,7 @@ pub struct DirectoryGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryGroupUser {
+pub struct DirectoryUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -138,7 +138,7 @@ pub struct Directory {
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<DirectoryGroupUser>,
+    pub user: Option<DirectoryUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
@@ -151,14 +151,14 @@ pub struct Disk {
     pub wipe_table: Option<bool>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileItemGroup {
+pub struct FileGroup {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileItemGroupUser {
+pub struct FileUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -172,14 +172,14 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contents: Option<FileContents>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<FileItemGroup>,
+    pub group: Option<FileGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<FileItemGroupUser>,
+    pub user: Option<FileUser>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "file-contents")]
@@ -217,7 +217,7 @@ pub struct LinkGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkGroupUser {
+pub struct LinkUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -235,7 +235,7 @@ pub struct Link {
     pub path: String,
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<LinkGroupUser>,
+    pub user: Option<LinkUser>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 pub struct NodeGroup {
@@ -245,7 +245,7 @@ pub struct NodeGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct NodeGroupUser {
+pub struct NodeUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -260,7 +260,7 @@ pub struct Node {
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<NodeGroupUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "partition")]

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -1,3 +1,5 @@
+// Generated code; do not modify
+
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "ca-reference")]
 pub struct CaReference {
@@ -274,10 +276,10 @@ pub struct Partition {
     pub should_exist: Option<bool>,
     #[serde(default)]
     #[serde(rename = "sizeMiB")]
-    pub size_mi_b: Option<i64>,
+    pub size_mib: Option<i64>,
     #[serde(default)]
     #[serde(rename = "startMiB")]
-    pub start_mi_b: Option<i64>,
+    pub start_mib: Option<i64>,
     #[serde(default)]
     #[serde(rename = "typeGuid")]
     pub type_guid: Option<String>,

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -1,0 +1,356 @@
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "ca-reference")]
+pub struct CaReference {
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification: Option<Verification>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "config-reference")]
+pub struct ConfigReference {
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification: Option<Verification>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "ignition-config")]
+pub struct IgnitionConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge: Option<Vec<ConfigReference>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replace: Option<ConfigReference>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct SecurityTls {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "certificateAuthorities")]
+    pub certificate_authorities: Option<Vec<CaReference>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "security")]
+pub struct Security {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls: Option<SecurityTls>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "timeouts")]
+pub struct Timeouts {
+    #[serde(default)]
+    #[serde(rename = "httpResponseHeaders")]
+    pub http_response_headers: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "httpTotal")]
+    pub http_total: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "ignition")]
+pub struct Ignition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<IgnitionConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<Security>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeouts: Option<Timeouts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "group")]
+pub struct Group {
+    #[serde(default)]
+    pub gid: Option<i64>,
+    pub name: String,
+    #[serde(default)]
+    #[serde(rename = "passwordHash")]
+    pub password_hash: Option<String>,
+    #[serde(default)]
+    pub system: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "user")]
+pub struct User {
+    #[serde(default)]
+    pub gecos: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<String>>,
+    #[serde(default)]
+    #[serde(rename = "homeDir")]
+    pub home_dir: Option<String>,
+    pub name: String,
+    #[serde(default)]
+    #[serde(rename = "noCreateHome")]
+    pub no_create_home: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "noLogInit")]
+    pub no_log_init: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "noUserGroup")]
+    pub no_user_group: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "passwordHash")]
+    pub password_hash: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "primaryGroup")]
+    pub primary_group: Option<String>,
+    #[serde(default)]
+    pub shell: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "sshAuthorizedKeys")]
+    pub ssh_authorized_keys: Option<Vec<String>>,
+    #[serde(default)]
+    pub system: Option<bool>,
+    #[serde(default)]
+    pub uid: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "passwd")]
+pub struct Passwd {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<Group>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub users: Option<Vec<User>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct DirectoryGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct DirectoryGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "directory")]
+pub struct Directory {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<DirectoryGroup>,
+    #[serde(default)]
+    pub mode: Option<i64>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<DirectoryGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "disk")]
+pub struct Disk {
+    pub device: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partitions: Option<Vec<Partition>>,
+    #[serde(default)]
+    #[serde(rename = "wipeTable")]
+    pub wipe_table: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct FileItemGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct FileItemGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "file")]
+pub struct File {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub append: Option<Vec<FileContents>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contents: Option<FileContents>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<FileItemGroup>,
+    #[serde(default)]
+    pub mode: Option<i64>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<FileItemGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "file-contents")]
+pub struct FileContents {
+    #[serde(default)]
+    pub compression: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification: Option<Verification>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "filesystem")]
+pub struct Filesystem {
+    pub device: String,
+    #[serde(default)]
+    pub format: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub uuid: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "wipeFilesystem")]
+    pub wipe_filesystem: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct LinkGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct LinkGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "link")]
+pub struct Link {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<LinkGroup>,
+    #[serde(default)]
+    pub hard: Option<bool>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    pub target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<LinkGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct NodeGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct NodeGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "node")]
+pub struct Node {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<NodeGroup>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<NodeGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "partition")]
+pub struct Partition {
+    #[serde(default)]
+    pub guid: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "shouldExist")]
+    pub should_exist: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "sizeMiB")]
+    pub size_mi_b: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "startMiB")]
+    pub start_mi_b: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "typeGuid")]
+    pub type_guid: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "wipePartitionEntry")]
+    pub wipe_partition_entry: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "raid")]
+pub struct Raid {
+    pub devices: Vec<String>,
+    pub level: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub spares: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "storage")]
+pub struct Storage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directories: Option<Vec<Directory>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disks: Option<Vec<Disk>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files: Option<Vec<File>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filesystems: Option<Vec<Filesystem>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raid: Option<Vec<Raid>>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "dropin")]
+pub struct Dropin {
+    #[serde(default)]
+    pub contents: Option<String>,
+    pub name: String,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "unit")]
+pub struct Unit {
+    #[serde(default)]
+    pub contents: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dropins: Option<Vec<Dropin>>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub mask: Option<bool>,
+    pub name: String,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "systemd")]
+pub struct Systemd {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub units: Option<Vec<Unit>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "verification")]
+pub struct Verification {
+    #[serde(default)]
+    pub hash: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct Config {
+    pub ignition: Ignition,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub passwd: Option<Passwd>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage: Option<Storage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub systemd: Option<Systemd>,
+}

--- a/src/v3_1/mod.rs
+++ b/src/v3_1/mod.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use schemafy::schemafy;
 use serde::{Deserialize, Serialize};
 
-schemafy!(
-    root: Config
-    "src/v3_1/ignition.json"
-);
+include!("schema.rs");

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -151,14 +151,14 @@ pub struct DirectoryUser {
 #[serde(rename = "directory")]
 pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<DirectoryGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<DirectoryUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
@@ -192,14 +192,14 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contents: Option<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<FileGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<FileUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "filesystem")]
@@ -240,7 +240,7 @@ pub struct LinkUser {
 #[serde(rename = "link")]
 pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<LinkGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub hard: Option<bool>,
     #[serde(default)]
@@ -248,7 +248,7 @@ pub struct Link {
     pub path: String,
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<LinkUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 pub struct NodeGroup {

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -133,20 +133,6 @@ pub struct Resource {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification: Option<Verification>,
 }
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "directory")]
 pub struct Directory {
@@ -169,20 +155,6 @@ pub struct Disk {
     #[serde(default)]
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "file")]
@@ -221,20 +193,6 @@ pub struct Filesystem {
     #[serde(default)]
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "link")]

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -1,0 +1,369 @@
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct HttpHeadersItem {
+    pub name: String,
+    #[serde(default)]
+    pub value: Option<String>,
+}
+pub type HttpHeaders = Vec<HttpHeadersItem>;
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "ignition-config")]
+pub struct IgnitionConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge: Option<Vec<Resource>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replace: Option<Resource>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "proxy")]
+pub struct Proxy {
+    #[serde(default)]
+    #[serde(rename = "httpProxy")]
+    pub http_proxy: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "httpsProxy")]
+    pub https_proxy: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "noProxy")]
+    pub no_proxy: Option<Vec<Option<String>>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct SecurityTls {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "certificateAuthorities")]
+    pub certificate_authorities: Option<Vec<Resource>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "security")]
+pub struct Security {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls: Option<SecurityTls>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "timeouts")]
+pub struct Timeouts {
+    #[serde(default)]
+    #[serde(rename = "httpResponseHeaders")]
+    pub http_response_headers: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "httpTotal")]
+    pub http_total: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "ignition")]
+pub struct Ignition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<IgnitionConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proxy: Option<Proxy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<Security>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeouts: Option<Timeouts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "group")]
+pub struct Group {
+    #[serde(default)]
+    pub gid: Option<i64>,
+    pub name: String,
+    #[serde(default)]
+    #[serde(rename = "passwordHash")]
+    pub password_hash: Option<String>,
+    #[serde(default)]
+    pub system: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "user")]
+pub struct User {
+    #[serde(default)]
+    pub gecos: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<String>>,
+    #[serde(default)]
+    #[serde(rename = "homeDir")]
+    pub home_dir: Option<String>,
+    pub name: String,
+    #[serde(default)]
+    #[serde(rename = "noCreateHome")]
+    pub no_create_home: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "noLogInit")]
+    pub no_log_init: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "noUserGroup")]
+    pub no_user_group: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "passwordHash")]
+    pub password_hash: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "primaryGroup")]
+    pub primary_group: Option<String>,
+    #[serde(default)]
+    pub shell: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "sshAuthorizedKeys")]
+    pub ssh_authorized_keys: Option<Vec<String>>,
+    #[serde(default)]
+    pub system: Option<bool>,
+    #[serde(default)]
+    pub uid: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "passwd")]
+pub struct Passwd {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<Group>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub users: Option<Vec<User>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "resource")]
+pub struct Resource {
+    #[serde(default)]
+    pub compression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "httpHeaders")]
+    pub http_headers: Option<HttpHeaders>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification: Option<Verification>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct DirectoryGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct DirectoryGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "directory")]
+pub struct Directory {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<DirectoryGroup>,
+    #[serde(default)]
+    pub mode: Option<i64>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<DirectoryGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "disk")]
+pub struct Disk {
+    pub device: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partitions: Option<Vec<Partition>>,
+    #[serde(default)]
+    #[serde(rename = "wipeTable")]
+    pub wipe_table: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct FileItemGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct FileItemGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "file")]
+pub struct File {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub append: Option<Vec<Resource>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contents: Option<Resource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<FileItemGroup>,
+    #[serde(default)]
+    pub mode: Option<i64>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<FileItemGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "filesystem")]
+pub struct Filesystem {
+    pub device: String,
+    #[serde(default)]
+    pub format: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mountOptions")]
+    pub mount_options: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub uuid: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "wipeFilesystem")]
+    pub wipe_filesystem: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct LinkGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct LinkGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "link")]
+pub struct Link {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<LinkGroup>,
+    #[serde(default)]
+    pub hard: Option<bool>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    pub target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<LinkGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct NodeGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct NodeGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "node")]
+pub struct Node {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<NodeGroup>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<NodeGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "partition")]
+pub struct Partition {
+    #[serde(default)]
+    pub guid: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "shouldExist")]
+    pub should_exist: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "sizeMiB")]
+    pub size_mi_b: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "startMiB")]
+    pub start_mi_b: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "typeGuid")]
+    pub type_guid: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "wipePartitionEntry")]
+    pub wipe_partition_entry: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "raid")]
+pub struct Raid {
+    pub devices: Vec<String>,
+    pub level: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub spares: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "storage")]
+pub struct Storage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directories: Option<Vec<Directory>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disks: Option<Vec<Disk>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files: Option<Vec<File>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filesystems: Option<Vec<Filesystem>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raid: Option<Vec<Raid>>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "dropin")]
+pub struct Dropin {
+    #[serde(default)]
+    pub contents: Option<String>,
+    pub name: String,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "unit")]
+pub struct Unit {
+    #[serde(default)]
+    pub contents: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dropins: Option<Vec<Dropin>>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub mask: Option<bool>,
+    pub name: String,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "systemd")]
+pub struct Systemd {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub units: Option<Vec<Unit>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "verification")]
+pub struct Verification {
+    #[serde(default)]
+    pub hash: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct Config {
+    pub ignition: Ignition,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub passwd: Option<Passwd>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage: Option<Storage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub systemd: Option<Systemd>,
+}

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -141,7 +141,7 @@ pub struct DirectoryGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryGroupUser {
+pub struct DirectoryUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -158,7 +158,7 @@ pub struct Directory {
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<DirectoryGroupUser>,
+    pub user: Option<DirectoryUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
@@ -171,14 +171,14 @@ pub struct Disk {
     pub wipe_table: Option<bool>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileItemGroup {
+pub struct FileGroup {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileItemGroupUser {
+pub struct FileUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -192,14 +192,14 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contents: Option<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<FileItemGroup>,
+    pub group: Option<FileGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<FileItemGroupUser>,
+    pub user: Option<FileUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "filesystem")]
@@ -230,7 +230,7 @@ pub struct LinkGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkGroupUser {
+pub struct LinkUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -248,7 +248,7 @@ pub struct Link {
     pub path: String,
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<LinkGroupUser>,
+    pub user: Option<LinkUser>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 pub struct NodeGroup {
@@ -258,7 +258,7 @@ pub struct NodeGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct NodeGroupUser {
+pub struct NodeUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -273,7 +273,7 @@ pub struct Node {
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<NodeGroupUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "partition")]

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -1,3 +1,5 @@
+// Generated code; do not modify
+
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct HttpHeadersItem {
     pub name: String,
@@ -287,10 +289,10 @@ pub struct Partition {
     pub should_exist: Option<bool>,
     #[serde(default)]
     #[serde(rename = "sizeMiB")]
-    pub size_mi_b: Option<i64>,
+    pub size_mib: Option<i64>,
     #[serde(default)]
     #[serde(rename = "startMiB")]
-    pub start_mi_b: Option<i64>,
+    pub start_mib: Option<i64>,
     #[serde(default)]
     #[serde(rename = "typeGuid")]
     pub type_guid: Option<String>,

--- a/src/v3_2/mod.rs
+++ b/src/v3_2/mod.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use schemafy::schemafy;
 use serde::{Deserialize, Serialize};
 
-schemafy!(
-    root: Config
-    "src/v3_2/ignition.json"
-);
+include!("schema.rs");

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -1,3 +1,5 @@
+// Generated code; do not modify
+
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct HttpHeadersItem {
     pub name: String,
@@ -272,7 +274,7 @@ pub struct LuksClevis {
     pub threshold: Option<i64>,
     #[serde(default)]
     #[serde(rename = "tpm2")]
-    pub tpm_2: Option<bool>,
+    pub tpm2: Option<bool>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "luks")]
@@ -336,10 +338,10 @@ pub struct Partition {
     pub should_exist: Option<bool>,
     #[serde(default)]
     #[serde(rename = "sizeMiB")]
-    pub size_mi_b: Option<i64>,
+    pub size_mib: Option<i64>,
     #[serde(default)]
     #[serde(rename = "startMiB")]
-    pub start_mi_b: Option<i64>,
+    pub start_mib: Option<i64>,
     #[serde(default)]
     #[serde(rename = "typeGuid")]
     pub type_guid: Option<String>,

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -139,20 +139,6 @@ pub struct Resource {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification: Option<Verification>,
 }
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "directory")]
 pub struct Directory {
@@ -175,20 +161,6 @@ pub struct Disk {
     #[serde(default)]
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "file")]
@@ -227,20 +199,6 @@ pub struct Filesystem {
     #[serde(default)]
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "link")]

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -157,14 +157,14 @@ pub struct DirectoryUser {
 #[serde(rename = "directory")]
 pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<DirectoryGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<DirectoryUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
@@ -198,14 +198,14 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contents: Option<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<FileGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<FileUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "filesystem")]
@@ -246,7 +246,7 @@ pub struct LinkUser {
 #[serde(rename = "link")]
 pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<LinkGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub hard: Option<bool>,
     #[serde(default)]
@@ -254,7 +254,7 @@ pub struct Link {
     pub path: String,
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<LinkUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct LuksClevisCustom {

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -1,0 +1,428 @@
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct HttpHeadersItem {
+    pub name: String,
+    #[serde(default)]
+    pub value: Option<String>,
+}
+pub type HttpHeaders = Vec<HttpHeadersItem>;
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "ignition-config")]
+pub struct IgnitionConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge: Option<Vec<Resource>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replace: Option<Resource>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "proxy")]
+pub struct Proxy {
+    #[serde(default)]
+    #[serde(rename = "httpProxy")]
+    pub http_proxy: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "httpsProxy")]
+    pub https_proxy: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "noProxy")]
+    pub no_proxy: Option<Vec<Option<String>>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct SecurityTls {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "certificateAuthorities")]
+    pub certificate_authorities: Option<Vec<Resource>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "security")]
+pub struct Security {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls: Option<SecurityTls>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "timeouts")]
+pub struct Timeouts {
+    #[serde(default)]
+    #[serde(rename = "httpResponseHeaders")]
+    pub http_response_headers: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "httpTotal")]
+    pub http_total: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "ignition")]
+pub struct Ignition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<IgnitionConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proxy: Option<Proxy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<Security>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeouts: Option<Timeouts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "group")]
+pub struct Group {
+    #[serde(default)]
+    pub gid: Option<i64>,
+    pub name: String,
+    #[serde(default)]
+    #[serde(rename = "passwordHash")]
+    pub password_hash: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "shouldExist")]
+    pub should_exist: Option<bool>,
+    #[serde(default)]
+    pub system: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "user")]
+pub struct User {
+    #[serde(default)]
+    pub gecos: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<String>>,
+    #[serde(default)]
+    #[serde(rename = "homeDir")]
+    pub home_dir: Option<String>,
+    pub name: String,
+    #[serde(default)]
+    #[serde(rename = "noCreateHome")]
+    pub no_create_home: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "noLogInit")]
+    pub no_log_init: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "noUserGroup")]
+    pub no_user_group: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "passwordHash")]
+    pub password_hash: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "primaryGroup")]
+    pub primary_group: Option<String>,
+    #[serde(default)]
+    pub shell: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "shouldExist")]
+    pub should_exist: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "sshAuthorizedKeys")]
+    pub ssh_authorized_keys: Option<Vec<String>>,
+    #[serde(default)]
+    pub system: Option<bool>,
+    #[serde(default)]
+    pub uid: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "passwd")]
+pub struct Passwd {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<Group>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub users: Option<Vec<User>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "resource")]
+pub struct Resource {
+    #[serde(default)]
+    pub compression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "httpHeaders")]
+    pub http_headers: Option<HttpHeaders>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification: Option<Verification>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct DirectoryGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct DirectoryGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "directory")]
+pub struct Directory {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<DirectoryGroup>,
+    #[serde(default)]
+    pub mode: Option<i64>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<DirectoryGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "disk")]
+pub struct Disk {
+    pub device: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partitions: Option<Vec<Partition>>,
+    #[serde(default)]
+    #[serde(rename = "wipeTable")]
+    pub wipe_table: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct FileItemGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct FileItemGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "file")]
+pub struct File {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub append: Option<Vec<Resource>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contents: Option<Resource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<FileItemGroup>,
+    #[serde(default)]
+    pub mode: Option<i64>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<FileItemGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "filesystem")]
+pub struct Filesystem {
+    pub device: String,
+    #[serde(default)]
+    pub format: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mountOptions")]
+    pub mount_options: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub uuid: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "wipeFilesystem")]
+    pub wipe_filesystem: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct LinkGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct LinkGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "link")]
+pub struct Link {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<LinkGroup>,
+    #[serde(default)]
+    pub hard: Option<bool>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    pub target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<LinkGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct LuksClevisCustom {
+    pub config: String,
+    #[serde(default)]
+    #[serde(rename = "needsNetwork")]
+    pub needs_network: Option<bool>,
+    pub pin: String,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct LuksClevis {
+    #[serde(default)]
+    pub custom: Option<LuksClevisCustom>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tang: Option<Vec<Tang>>,
+    #[serde(default)]
+    pub threshold: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "tpm2")]
+    pub tpm_2: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "luks")]
+pub struct Luks {
+    #[serde(default)]
+    pub clevis: Option<LuksClevis>,
+    #[serde(default)]
+    pub device: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "keyFile")]
+    pub key_file: Option<Resource>,
+    #[serde(default)]
+    pub label: Option<String>,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub uuid: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "wipeVolume")]
+    pub wipe_volume: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct NodeGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct NodeGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "node")]
+pub struct Node {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<NodeGroup>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<NodeGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "partition")]
+pub struct Partition {
+    #[serde(default)]
+    pub guid: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number: Option<i64>,
+    #[serde(default)]
+    pub resize: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "shouldExist")]
+    pub should_exist: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "sizeMiB")]
+    pub size_mi_b: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "startMiB")]
+    pub start_mi_b: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "typeGuid")]
+    pub type_guid: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "wipePartitionEntry")]
+    pub wipe_partition_entry: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "raid")]
+pub struct Raid {
+    pub devices: Vec<String>,
+    pub level: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub spares: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "tang")]
+pub struct Tang {
+    #[serde(default)]
+    pub thumbprint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "storage")]
+pub struct Storage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directories: Option<Vec<Directory>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disks: Option<Vec<Disk>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files: Option<Vec<File>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filesystems: Option<Vec<Filesystem>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub luks: Option<Vec<Luks>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raid: Option<Vec<Raid>>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "dropin")]
+pub struct Dropin {
+    #[serde(default)]
+    pub contents: Option<String>,
+    pub name: String,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "unit")]
+pub struct Unit {
+    #[serde(default)]
+    pub contents: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dropins: Option<Vec<Dropin>>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub mask: Option<bool>,
+    pub name: String,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "systemd")]
+pub struct Systemd {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub units: Option<Vec<Unit>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "verification")]
+pub struct Verification {
+    #[serde(default)]
+    pub hash: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct Config {
+    pub ignition: Ignition,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub passwd: Option<Passwd>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage: Option<Storage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub systemd: Option<Systemd>,
+}

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -147,7 +147,7 @@ pub struct DirectoryGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryGroupUser {
+pub struct DirectoryUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -164,7 +164,7 @@ pub struct Directory {
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<DirectoryGroupUser>,
+    pub user: Option<DirectoryUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
@@ -177,14 +177,14 @@ pub struct Disk {
     pub wipe_table: Option<bool>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileItemGroup {
+pub struct FileGroup {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileItemGroupUser {
+pub struct FileUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -198,14 +198,14 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contents: Option<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<FileItemGroup>,
+    pub group: Option<FileGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<FileItemGroupUser>,
+    pub user: Option<FileUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "filesystem")]
@@ -236,7 +236,7 @@ pub struct LinkGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkGroupUser {
+pub struct LinkUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -254,7 +254,7 @@ pub struct Link {
     pub path: String,
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<LinkGroupUser>,
+    pub user: Option<LinkUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct LuksClevisCustom {
@@ -305,7 +305,7 @@ pub struct NodeGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct NodeGroupUser {
+pub struct NodeUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -320,7 +320,7 @@ pub struct Node {
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<NodeGroupUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "partition")]

--- a/src/v3_3/mod.rs
+++ b/src/v3_3/mod.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use schemafy::schemafy;
 use serde::{Deserialize, Serialize};
 
-schemafy!(
-    root: Config
-    "src/v3_3/ignition.json"
-);
+include!("schema.rs");

--- a/src/v3_3/schema.rs
+++ b/src/v3_3/schema.rs
@@ -192,14 +192,14 @@ pub struct DirectoryUser {
 #[serde(rename = "directory")]
 pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<DirectoryGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<DirectoryUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
@@ -233,14 +233,14 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contents: Option<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<FileGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<FileUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "filesystem")]
@@ -281,7 +281,7 @@ pub struct LinkUser {
 #[serde(rename = "link")]
 pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<LinkGroup>,
+    pub group: Option<NodeGroup>,
     #[serde(default)]
     pub hard: Option<bool>,
     #[serde(default)]
@@ -290,7 +290,7 @@ pub struct Link {
     #[serde(default)]
     pub target: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<LinkUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "luks")]

--- a/src/v3_3/schema.rs
+++ b/src/v3_3/schema.rs
@@ -1,3 +1,5 @@
+// Generated code; do not modify
+
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct HttpHeadersItem {
     pub name: String,
@@ -159,7 +161,7 @@ pub struct Clevis {
     pub threshold: Option<i64>,
     #[serde(default)]
     #[serde(rename = "tpm2")]
-    pub tpm_2: Option<bool>,
+    pub tpm2: Option<bool>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "clevisCustom")]
@@ -352,10 +354,10 @@ pub struct Partition {
     pub should_exist: Option<bool>,
     #[serde(default)]
     #[serde(rename = "sizeMiB")]
-    pub size_mi_b: Option<i64>,
+    pub size_mib: Option<i64>,
     #[serde(default)]
     #[serde(rename = "startMiB")]
-    pub start_mi_b: Option<i64>,
+    pub start_mib: Option<i64>,
     #[serde(default)]
     #[serde(rename = "typeGuid")]
     pub type_guid: Option<String>,

--- a/src/v3_3/schema.rs
+++ b/src/v3_3/schema.rs
@@ -1,0 +1,449 @@
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct HttpHeadersItem {
+    pub name: String,
+    #[serde(default)]
+    pub value: Option<String>,
+}
+pub type HttpHeaders = Vec<HttpHeadersItem>;
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "ignition-config")]
+pub struct IgnitionConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge: Option<Vec<Resource>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replace: Option<Resource>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "proxy")]
+pub struct Proxy {
+    #[serde(default)]
+    #[serde(rename = "httpProxy")]
+    pub http_proxy: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "httpsProxy")]
+    pub https_proxy: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "noProxy")]
+    pub no_proxy: Option<Vec<Option<String>>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct SecurityTls {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "certificateAuthorities")]
+    pub certificate_authorities: Option<Vec<Resource>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "security")]
+pub struct Security {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls: Option<SecurityTls>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "timeouts")]
+pub struct Timeouts {
+    #[serde(default)]
+    #[serde(rename = "httpResponseHeaders")]
+    pub http_response_headers: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "httpTotal")]
+    pub http_total: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "ignition")]
+pub struct Ignition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<IgnitionConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proxy: Option<Proxy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<Security>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeouts: Option<Timeouts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+pub type KernelArgument = String;
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "kernelArguments")]
+pub struct KernelArguments {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "shouldExist")]
+    pub should_exist: Option<Vec<KernelArgument>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "shouldNotExist")]
+    pub should_not_exist: Option<Vec<KernelArgument>>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "group")]
+pub struct Group {
+    #[serde(default)]
+    pub gid: Option<i64>,
+    pub name: String,
+    #[serde(default)]
+    #[serde(rename = "passwordHash")]
+    pub password_hash: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "shouldExist")]
+    pub should_exist: Option<bool>,
+    #[serde(default)]
+    pub system: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "user")]
+pub struct User {
+    #[serde(default)]
+    pub gecos: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<String>>,
+    #[serde(default)]
+    #[serde(rename = "homeDir")]
+    pub home_dir: Option<String>,
+    pub name: String,
+    #[serde(default)]
+    #[serde(rename = "noCreateHome")]
+    pub no_create_home: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "noLogInit")]
+    pub no_log_init: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "noUserGroup")]
+    pub no_user_group: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "passwordHash")]
+    pub password_hash: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "primaryGroup")]
+    pub primary_group: Option<String>,
+    #[serde(default)]
+    pub shell: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "shouldExist")]
+    pub should_exist: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "sshAuthorizedKeys")]
+    pub ssh_authorized_keys: Option<Vec<String>>,
+    #[serde(default)]
+    pub system: Option<bool>,
+    #[serde(default)]
+    pub uid: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "passwd")]
+pub struct Passwd {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<Group>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub users: Option<Vec<User>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "resource")]
+pub struct Resource {
+    #[serde(default)]
+    pub compression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "httpHeaders")]
+    pub http_headers: Option<HttpHeaders>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification: Option<Verification>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "clevis")]
+pub struct Clevis {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom: Option<ClevisCustom>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tang: Option<Vec<Tang>>,
+    #[serde(default)]
+    pub threshold: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "tpm2")]
+    pub tpm_2: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "clevisCustom")]
+pub struct ClevisCustom {
+    #[serde(default)]
+    pub config: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "needsNetwork")]
+    pub needs_network: Option<bool>,
+    #[serde(default)]
+    pub pin: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct DirectoryGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct DirectoryGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "directory")]
+pub struct Directory {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<DirectoryGroup>,
+    #[serde(default)]
+    pub mode: Option<i64>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<DirectoryGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "disk")]
+pub struct Disk {
+    pub device: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partitions: Option<Vec<Partition>>,
+    #[serde(default)]
+    #[serde(rename = "wipeTable")]
+    pub wipe_table: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct FileItemGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct FileItemGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "file")]
+pub struct File {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub append: Option<Vec<Resource>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contents: Option<Resource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<FileItemGroup>,
+    #[serde(default)]
+    pub mode: Option<i64>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<FileItemGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "filesystem")]
+pub struct Filesystem {
+    pub device: String,
+    #[serde(default)]
+    pub format: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mountOptions")]
+    pub mount_options: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub uuid: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "wipeFilesystem")]
+    pub wipe_filesystem: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct LinkGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct LinkGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "link")]
+pub struct Link {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<LinkGroup>,
+    #[serde(default)]
+    pub hard: Option<bool>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<LinkGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "luks")]
+pub struct Luks {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clevis: Option<Clevis>,
+    #[serde(default)]
+    pub device: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "keyFile")]
+    pub key_file: Option<Resource>,
+    #[serde(default)]
+    pub label: Option<String>,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub uuid: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "wipeVolume")]
+    pub wipe_volume: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct NodeGroup {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct NodeGroupUser {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "node")]
+pub struct Node {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<NodeGroup>,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<NodeGroupUser>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "partition")]
+pub struct Partition {
+    #[serde(default)]
+    pub guid: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number: Option<i64>,
+    #[serde(default)]
+    pub resize: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "shouldExist")]
+    pub should_exist: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "sizeMiB")]
+    pub size_mi_b: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "startMiB")]
+    pub start_mi_b: Option<i64>,
+    #[serde(default)]
+    #[serde(rename = "typeGuid")]
+    pub type_guid: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "wipePartitionEntry")]
+    pub wipe_partition_entry: Option<bool>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "raid")]
+pub struct Raid {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub devices: Option<Vec<String>>,
+    #[serde(default)]
+    pub level: Option<String>,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub spares: Option<i64>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "tang")]
+pub struct Tang {
+    #[serde(default)]
+    pub thumbprint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "storage")]
+pub struct Storage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directories: Option<Vec<Directory>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disks: Option<Vec<Disk>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files: Option<Vec<File>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filesystems: Option<Vec<Filesystem>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub luks: Option<Vec<Luks>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raid: Option<Vec<Raid>>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "dropin")]
+pub struct Dropin {
+    #[serde(default)]
+    pub contents: Option<String>,
+    pub name: String,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "unit")]
+pub struct Unit {
+    #[serde(default)]
+    pub contents: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dropins: Option<Vec<Dropin>>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub mask: Option<bool>,
+    pub name: String,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "systemd")]
+pub struct Systemd {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub units: Option<Vec<Unit>>,
+}
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename = "verification")]
+pub struct Verification {
+    #[serde(default)]
+    pub hash: Option<String>,
+}
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct Config {
+    pub ignition: Ignition,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "kernelArguments")]
+    pub kernel_arguments: Option<KernelArguments>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub passwd: Option<Passwd>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage: Option<Storage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub systemd: Option<Systemd>,
+}

--- a/src/v3_3/schema.rs
+++ b/src/v3_3/schema.rs
@@ -174,20 +174,6 @@ pub struct ClevisCustom {
     #[serde(default)]
     pub pin: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "directory")]
 pub struct Directory {
@@ -210,20 +196,6 @@ pub struct Disk {
     #[serde(default)]
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "file")]
@@ -262,20 +234,6 @@ pub struct Filesystem {
     #[serde(default)]
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkGroup {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
-}
-#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkUser {
-    #[serde(default)]
-    pub id: Option<i64>,
-    #[serde(default)]
-    pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "link")]

--- a/src/v3_3/schema.rs
+++ b/src/v3_3/schema.rs
@@ -182,7 +182,7 @@ pub struct DirectoryGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct DirectoryGroupUser {
+pub struct DirectoryUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -199,7 +199,7 @@ pub struct Directory {
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<DirectoryGroupUser>,
+    pub user: Option<DirectoryUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
@@ -212,14 +212,14 @@ pub struct Disk {
     pub wipe_table: Option<bool>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileItemGroup {
+pub struct FileGroup {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct FileItemGroupUser {
+pub struct FileUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -233,14 +233,14 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contents: Option<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<FileItemGroup>,
+    pub group: Option<FileGroup>,
     #[serde(default)]
     pub mode: Option<i64>,
     #[serde(default)]
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<FileItemGroupUser>,
+    pub user: Option<FileUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "filesystem")]
@@ -271,7 +271,7 @@ pub struct LinkGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct LinkGroupUser {
+pub struct LinkUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -290,7 +290,7 @@ pub struct Link {
     #[serde(default)]
     pub target: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<LinkGroupUser>,
+    pub user: Option<LinkUser>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "luks")]
@@ -321,7 +321,7 @@ pub struct NodeGroup {
     pub name: Option<String>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct NodeGroupUser {
+pub struct NodeUser {
     #[serde(default)]
     pub id: Option<i64>,
     #[serde(default)]
@@ -336,7 +336,7 @@ pub struct Node {
     pub overwrite: Option<bool>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<NodeGroupUser>,
+    pub user: Option<NodeUser>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "partition")]


### PR DESCRIPTION
Store generated Rust code in Git, and regenerate it only when built with `cargo build --features regenerate`.  Then apply fixups:

- Rewrite awkward autogenerated field names (fixes #2)
- Fix stray `Item` and `Group` in node user and group structs (works around Marwes/schemafy#49)
- Replace context-specific `DirectoryUser`/`DirectoryGroup`/etc. with generic `NodeUser`/`NodeGroup` structs and delete the context-specific ones (works around https://github.com/Marwes/schemafy/issues/50)

Requires Git version of Schemafy.