### PR TITLE
workflows: fail CI on non-empty diff of generated files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,13 @@ jobs:
         run: cargo build
       - name: cargo build (regenerate)
         run: cargo build --features regenerate
+      - name: Check generated files for changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Found local changes after regenerating generated files:"
+            git --no-pager diff --color=always
+            exit 1
+          fi
   tests-other-channels:
     name: "Tests, unstable toolchain"
     runs-on: ubuntu-latest


### PR DESCRIPTION
On the pinned toolchain only, fail if the generated files are stale.  This is intended to catch Dependabot schemafy updates that would modify the generated files, but is also useful to catch `build.rs` changes that haven't been propagated to the generated files.