### PR TITLE
Always derive `Default`

### DIFF
--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -1,6 +1,6 @@
 // Generated code; do not modify
 
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "ca-reference")]
 pub struct CaReference {
     pub source: String,
@@ -57,7 +57,7 @@ pub struct Ignition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "group")]
 pub struct Group {
     #[serde(default)]
@@ -69,7 +69,7 @@ pub struct Group {
     #[serde(default)]
     pub system: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "user")]
 pub struct User {
     #[serde(default)]
@@ -113,7 +113,7 @@ pub struct Passwd {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub users: Option<Vec<User>>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "directory")]
 pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -126,7 +126,7 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "disk")]
 pub struct Disk {
     pub device: String,
@@ -136,7 +136,7 @@ pub struct Disk {
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "file")]
 pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -163,7 +163,7 @@ pub struct FileContents {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification: Option<Verification>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "filesystem")]
 pub struct Filesystem {
     pub device: String,
@@ -181,7 +181,7 @@ pub struct Filesystem {
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "link")]
 pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -209,7 +209,7 @@ pub struct NodeUser {
     #[serde(default)]
     pub name: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "node")]
 pub struct Node {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -245,7 +245,7 @@ pub struct Partition {
     #[serde(rename = "wipePartitionEntry")]
     pub wipe_partition_entry: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "raid")]
 pub struct Raid {
     pub devices: Vec<String>,
@@ -272,14 +272,14 @@ pub struct Storage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub raid: Option<Vec<Raid>>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "dropin")]
 pub struct Dropin {
     #[serde(default)]
     pub contents: Option<String>,
     pub name: String,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "unit")]
 pub struct Unit {
     #[serde(default)]
@@ -304,7 +304,7 @@ pub struct Verification {
     #[serde(default)]
     pub hash: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct Config {
     pub ignition: Ignition,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -1,6 +1,6 @@
 // Generated code; do not modify
 
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct HttpHeadersItem {
     pub name: String,
     #[serde(default)]
@@ -64,7 +64,7 @@ pub struct Ignition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "group")]
 pub struct Group {
     #[serde(default)]
@@ -76,7 +76,7 @@ pub struct Group {
     #[serde(default)]
     pub system: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "user")]
 pub struct User {
     #[serde(default)]
@@ -133,7 +133,7 @@ pub struct Resource {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification: Option<Verification>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "directory")]
 pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -146,7 +146,7 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "disk")]
 pub struct Disk {
     pub device: String,
@@ -156,7 +156,7 @@ pub struct Disk {
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "file")]
 pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -173,7 +173,7 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "filesystem")]
 pub struct Filesystem {
     pub device: String,
@@ -194,7 +194,7 @@ pub struct Filesystem {
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "link")]
 pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -222,7 +222,7 @@ pub struct NodeUser {
     #[serde(default)]
     pub name: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "node")]
 pub struct Node {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -258,7 +258,7 @@ pub struct Partition {
     #[serde(rename = "wipePartitionEntry")]
     pub wipe_partition_entry: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "raid")]
 pub struct Raid {
     pub devices: Vec<String>,
@@ -285,14 +285,14 @@ pub struct Storage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub raid: Option<Vec<Raid>>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "dropin")]
 pub struct Dropin {
     #[serde(default)]
     pub contents: Option<String>,
     pub name: String,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "unit")]
 pub struct Unit {
     #[serde(default)]
@@ -317,7 +317,7 @@ pub struct Verification {
     #[serde(default)]
     pub hash: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct Config {
     pub ignition: Ignition,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -1,6 +1,6 @@
 // Generated code; do not modify
 
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct HttpHeadersItem {
     pub name: String,
     #[serde(default)]
@@ -64,7 +64,7 @@ pub struct Ignition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "group")]
 pub struct Group {
     #[serde(default)]
@@ -79,7 +79,7 @@ pub struct Group {
     #[serde(default)]
     pub system: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "user")]
 pub struct User {
     #[serde(default)]
@@ -139,7 +139,7 @@ pub struct Resource {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification: Option<Verification>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "directory")]
 pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -152,7 +152,7 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "disk")]
 pub struct Disk {
     pub device: String,
@@ -162,7 +162,7 @@ pub struct Disk {
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "file")]
 pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -179,7 +179,7 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "filesystem")]
 pub struct Filesystem {
     pub device: String,
@@ -200,7 +200,7 @@ pub struct Filesystem {
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "link")]
 pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -214,7 +214,7 @@ pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct LuksClevisCustom {
     pub config: String,
     #[serde(default)]
@@ -234,7 +234,7 @@ pub struct LuksClevis {
     #[serde(rename = "tpm2")]
     pub tpm2: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "luks")]
 pub struct Luks {
     #[serde(default)]
@@ -269,7 +269,7 @@ pub struct NodeUser {
     #[serde(default)]
     pub name: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "node")]
 pub struct Node {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -307,7 +307,7 @@ pub struct Partition {
     #[serde(rename = "wipePartitionEntry")]
     pub wipe_partition_entry: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "raid")]
 pub struct Raid {
     pub devices: Vec<String>,
@@ -344,14 +344,14 @@ pub struct Storage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub raid: Option<Vec<Raid>>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "dropin")]
 pub struct Dropin {
     #[serde(default)]
     pub contents: Option<String>,
     pub name: String,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "unit")]
 pub struct Unit {
     #[serde(default)]
@@ -376,7 +376,7 @@ pub struct Verification {
     #[serde(default)]
     pub hash: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct Config {
     pub ignition: Ignition,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v3_3/schema.rs
+++ b/src/v3_3/schema.rs
@@ -1,6 +1,6 @@
 // Generated code; do not modify
 
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct HttpHeadersItem {
     pub name: String,
     #[serde(default)]
@@ -75,7 +75,7 @@ pub struct KernelArguments {
     #[serde(rename = "shouldNotExist")]
     pub should_not_exist: Option<Vec<KernelArgument>>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "group")]
 pub struct Group {
     #[serde(default)]
@@ -90,7 +90,7 @@ pub struct Group {
     #[serde(default)]
     pub system: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "user")]
 pub struct User {
     #[serde(default)]
@@ -174,7 +174,7 @@ pub struct ClevisCustom {
     #[serde(default)]
     pub pin: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "directory")]
 pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -187,7 +187,7 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "disk")]
 pub struct Disk {
     pub device: String,
@@ -197,7 +197,7 @@ pub struct Disk {
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "file")]
 pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -214,7 +214,7 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "filesystem")]
 pub struct Filesystem {
     pub device: String,
@@ -235,7 +235,7 @@ pub struct Filesystem {
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "link")]
 pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -250,7 +250,7 @@ pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "luks")]
 pub struct Luks {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -285,7 +285,7 @@ pub struct NodeUser {
     #[serde(default)]
     pub name: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "node")]
 pub struct Node {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -323,7 +323,7 @@ pub struct Partition {
     #[serde(rename = "wipePartitionEntry")]
     pub wipe_partition_entry: Option<bool>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "raid")]
 pub struct Raid {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -362,14 +362,14 @@ pub struct Storage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub raid: Option<Vec<Raid>>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "dropin")]
 pub struct Dropin {
     #[serde(default)]
     pub contents: Option<String>,
     pub name: String,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 #[serde(rename = "unit")]
 pub struct Unit {
     #[serde(default)]
@@ -394,7 +394,7 @@ pub struct Verification {
     #[serde(default)]
     pub hash: Option<String>,
 }
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct Config {
     pub ignition: Ignition,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
If a struct derives `Serialize` but not `Default`, which schemafy does when a struct contains a required field, inject a derive for `Default`.  This allows using Ignition config structs without manually specifying all the fields, but it also generates defaults for mandatory fields.  Generating explicit `new()` methods would be better, but also more work.

I'm on the fence about this one.  It makes using the structs more ergonomic, but in a way that isn't fully idiomatic.