### PR TITLE
Generate `new()` functions for structs with non-`Option` fields; implement `Default` for `Config`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,16 +14,18 @@
 
 #[cfg(feature = "regenerate")]
 mod regenerate {
+    use std::collections::HashMap;
     use std::fs::read_dir;
     use std::io::{Read, Write};
     use std::path::Path;
     use std::process::{Command, Stdio};
 
     use anyhow::{anyhow, bail, Context, Result};
-    use proc_macro2::{Ident, Span};
+    use proc_macro2::{Ident, Span, TokenStream};
     use quote::quote;
     use schemafy_lib::Generator;
     use syn::visit_mut::{self, VisitMut};
+    use syn::{parse_quote, Item};
     use tempfile::NamedTempFile;
 
     pub fn regenerate() -> Result<()> {
@@ -59,7 +61,7 @@ mod regenerate {
         let mut tree = syn::parse_file(&buf)?;
 
         // modify it
-        Rewriter.visit_file_mut(&mut tree);
+        Rewriter::default().visit_file_mut(&mut tree);
 
         // run it through rustfmt and write it out
         let output = format!("// Generated code; do not modify\n\n{}", quote!(#tree));
@@ -85,7 +87,14 @@ mod regenerate {
         Ok(())
     }
 
-    struct Rewriter;
+    #[derive(Default)]
+    struct Rewriter {
+        struct_impls: HashMap<Ident, Item>,
+
+        // reset for every struct
+        constructor_args: Vec<TokenStream>,
+        field_initializers: Vec<TokenStream>,
+    }
 
     impl VisitMut for Rewriter {
         fn visit_field_mut(&mut self, node: &mut syn::Field) {
@@ -103,7 +112,48 @@ mod regenerate {
                     _ => ident,
                 })
             }
+
+            // save field initializer and possible constructor arg for new(),
+            // depending whether the field is Option<T>
+            if let syn::Type::Path(ty) = &node.ty {
+                let ident = node.ident.clone().expect("anonymous field");
+                // check if the outermost path segment is Option
+                if ty.path.segments.first().map(|v| &v.ident)
+                    == Some(&Ident::new("Option", Span::call_site()))
+                {
+                    self.field_initializers.push(quote! { #ident: None });
+                } else {
+                    self.constructor_args.push(quote! { #ident: #ty });
+                    self.field_initializers.push(quote! { #ident });
+                }
+            }
+
             visit_mut::visit_field_mut(self, node);
+        }
+
+        fn visit_item_struct_mut(&mut self, node: &mut syn::ItemStruct) {
+            // visit struct declaration
+            self.constructor_args.clear();
+            self.field_initializers.clear();
+            visit_mut::visit_item_struct_mut(self, node);
+
+            // if there are non-Option fields, generate a new() method,
+            // otherwise assume schemafy derived Default
+            if !self.constructor_args.is_empty() {
+                let name = &node.ident;
+                let args = &self.constructor_args;
+                let initializers = &self.field_initializers;
+                let item = parse_quote! {
+                    impl #name {
+                        pub fn new(#(#args),*) -> Self {
+                            Self {
+                                #(#initializers),*
+                            }
+                        }
+                    }
+                };
+                self.struct_impls.insert(name.clone(), item);
+            }
         }
 
         fn visit_path_segment_mut(&mut self, node: &mut syn::PathSegment) {
@@ -130,14 +180,14 @@ mod regenerate {
         }
 
         fn visit_file_mut(&mut self, node: &mut syn::File) {
-            // drop definitions for now-unused user/group structs
-            // https://github.com/Marwes/schemafy/issues/50
             visit_mut::visit_file_mut(self, node);
             node.items = node
                 .items
                 .drain(..)
+                // drop definitions for now-unused user/group structs
+                // https://github.com/Marwes/schemafy/issues/50
                 .filter(|item| match item {
-                    syn::Item::Struct(s) => !matches!(
+                    Item::Struct(s) => !matches!(
                         s.ident.to_string().as_str(),
                         "DirectoryGroup"
                             | "DirectoryUser"
@@ -148,7 +198,16 @@ mod regenerate {
                     ),
                     _ => true,
                 })
+                // add constructor implementations
+                .flat_map(|item| match &item {
+                    Item::Struct(s) => match self.struct_impls.remove(&s.ident) {
+                        Some(item_impl) => vec![item, item_impl],
+                        None => vec![item],
+                    },
+                    _ => vec![item],
+                })
                 .collect();
+            assert!(self.struct_impls.is_empty());
         }
     }
 }

--- a/src/v3_0/mod.rs
+++ b/src/v3_0/mod.rs
@@ -15,3 +15,17 @@
 use serde::{Deserialize, Serialize};
 
 include!("schema.rs");
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            ignition: Ignition {
+                version: Some("3.0.0".into()),
+                ..Default::default()
+            },
+            passwd: None,
+            storage: None,
+            systemd: None,
+        }
+    }
+}

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -7,6 +7,14 @@ pub struct CaReference {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification: Option<Verification>,
 }
+impl CaReference {
+    pub fn new(source: String) -> Self {
+        Self {
+            source,
+            verification: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "config-reference")]
 pub struct ConfigReference {
@@ -69,6 +77,16 @@ pub struct Group {
     #[serde(default)]
     pub system: Option<bool>,
 }
+impl Group {
+    pub fn new(name: String) -> Self {
+        Self {
+            gid: None,
+            name,
+            password_hash: None,
+            system: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "user")]
 pub struct User {
@@ -105,6 +123,25 @@ pub struct User {
     #[serde(default)]
     pub uid: Option<i64>,
 }
+impl User {
+    pub fn new(name: String) -> Self {
+        Self {
+            gecos: None,
+            groups: None,
+            home_dir: None,
+            name,
+            no_create_home: None,
+            no_log_init: None,
+            no_user_group: None,
+            password_hash: None,
+            primary_group: None,
+            shell: None,
+            ssh_authorized_keys: None,
+            system: None,
+            uid: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "passwd")]
 pub struct Passwd {
@@ -126,6 +163,17 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
+impl Directory {
+    pub fn new(path: String) -> Self {
+        Self {
+            group: None,
+            mode: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
 pub struct Disk {
@@ -135,6 +183,15 @@ pub struct Disk {
     #[serde(default)]
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
+}
+impl Disk {
+    pub fn new(device: String) -> Self {
+        Self {
+            device,
+            partitions: None,
+            wipe_table: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "file")]
@@ -152,6 +209,19 @@ pub struct File {
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl File {
+    pub fn new(path: String) -> Self {
+        Self {
+            append: None,
+            contents: None,
+            group: None,
+            mode: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "file-contents")]
@@ -181,6 +251,19 @@ pub struct Filesystem {
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
 }
+impl Filesystem {
+    pub fn new(device: String) -> Self {
+        Self {
+            device,
+            format: None,
+            label: None,
+            options: None,
+            path: None,
+            uuid: None,
+            wipe_filesystem: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "link")]
 pub struct Link {
@@ -194,6 +277,18 @@ pub struct Link {
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl Link {
+    pub fn new(path: String, target: String) -> Self {
+        Self {
+            group: None,
+            hard: None,
+            overwrite: None,
+            path,
+            target,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 pub struct NodeGroup {
@@ -219,6 +314,16 @@ pub struct Node {
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl Node {
+    pub fn new(path: String) -> Self {
+        Self {
+            group: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "partition")]
@@ -256,6 +361,17 @@ pub struct Raid {
     #[serde(default)]
     pub spares: Option<i64>,
 }
+impl Raid {
+    pub fn new(devices: Vec<String>, level: String, name: String) -> Self {
+        Self {
+            devices,
+            level,
+            name,
+            options: None,
+            spares: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "storage")]
 pub struct Storage {
@@ -279,6 +395,14 @@ pub struct Dropin {
     pub contents: Option<String>,
     pub name: String,
 }
+impl Dropin {
+    pub fn new(name: String) -> Self {
+        Self {
+            contents: None,
+            name,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "unit")]
 pub struct Unit {
@@ -291,6 +415,17 @@ pub struct Unit {
     #[serde(default)]
     pub mask: Option<bool>,
     pub name: String,
+}
+impl Unit {
+    pub fn new(name: String) -> Self {
+        Self {
+            contents: None,
+            dropins: None,
+            enabled: None,
+            mask: None,
+            name,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "systemd")]
@@ -313,4 +448,14 @@ pub struct Config {
     pub storage: Option<Storage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub systemd: Option<Systemd>,
+}
+impl Config {
+    pub fn new(ignition: Ignition) -> Self {
+        Self {
+            ignition,
+            passwd: None,
+            storage: None,
+            systemd: None,
+        }
+    }
 }

--- a/src/v3_1/mod.rs
+++ b/src/v3_1/mod.rs
@@ -15,3 +15,17 @@
 use serde::{Deserialize, Serialize};
 
 include!("schema.rs");
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            ignition: Ignition {
+                version: Some("3.1.0".into()),
+                ..Default::default()
+            },
+            passwd: None,
+            storage: None,
+            systemd: None,
+        }
+    }
+}

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -6,6 +6,11 @@ pub struct HttpHeadersItem {
     #[serde(default)]
     pub value: Option<String>,
 }
+impl HttpHeadersItem {
+    pub fn new(name: String) -> Self {
+        Self { name, value: None }
+    }
+}
 pub type HttpHeaders = Vec<HttpHeadersItem>;
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "ignition-config")]
@@ -76,6 +81,16 @@ pub struct Group {
     #[serde(default)]
     pub system: Option<bool>,
 }
+impl Group {
+    pub fn new(name: String) -> Self {
+        Self {
+            gid: None,
+            name,
+            password_hash: None,
+            system: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "user")]
 pub struct User {
@@ -112,6 +127,25 @@ pub struct User {
     #[serde(default)]
     pub uid: Option<i64>,
 }
+impl User {
+    pub fn new(name: String) -> Self {
+        Self {
+            gecos: None,
+            groups: None,
+            home_dir: None,
+            name,
+            no_create_home: None,
+            no_log_init: None,
+            no_user_group: None,
+            password_hash: None,
+            primary_group: None,
+            shell: None,
+            ssh_authorized_keys: None,
+            system: None,
+            uid: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "passwd")]
 pub struct Passwd {
@@ -146,6 +180,17 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
+impl Directory {
+    pub fn new(path: String) -> Self {
+        Self {
+            group: None,
+            mode: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
 pub struct Disk {
@@ -155,6 +200,15 @@ pub struct Disk {
     #[serde(default)]
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
+}
+impl Disk {
+    pub fn new(device: String) -> Self {
+        Self {
+            device,
+            partitions: None,
+            wipe_table: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "file")]
@@ -172,6 +226,19 @@ pub struct File {
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl File {
+    pub fn new(path: String) -> Self {
+        Self {
+            append: None,
+            contents: None,
+            group: None,
+            mode: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "filesystem")]
@@ -194,6 +261,20 @@ pub struct Filesystem {
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
 }
+impl Filesystem {
+    pub fn new(device: String) -> Self {
+        Self {
+            device,
+            format: None,
+            label: None,
+            mount_options: None,
+            options: None,
+            path: None,
+            uuid: None,
+            wipe_filesystem: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "link")]
 pub struct Link {
@@ -207,6 +288,18 @@ pub struct Link {
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl Link {
+    pub fn new(path: String, target: String) -> Self {
+        Self {
+            group: None,
+            hard: None,
+            overwrite: None,
+            path,
+            target,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 pub struct NodeGroup {
@@ -232,6 +325,16 @@ pub struct Node {
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl Node {
+    pub fn new(path: String) -> Self {
+        Self {
+            group: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "partition")]
@@ -269,6 +372,17 @@ pub struct Raid {
     #[serde(default)]
     pub spares: Option<i64>,
 }
+impl Raid {
+    pub fn new(devices: Vec<String>, level: String, name: String) -> Self {
+        Self {
+            devices,
+            level,
+            name,
+            options: None,
+            spares: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "storage")]
 pub struct Storage {
@@ -292,6 +406,14 @@ pub struct Dropin {
     pub contents: Option<String>,
     pub name: String,
 }
+impl Dropin {
+    pub fn new(name: String) -> Self {
+        Self {
+            contents: None,
+            name,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "unit")]
 pub struct Unit {
@@ -304,6 +426,17 @@ pub struct Unit {
     #[serde(default)]
     pub mask: Option<bool>,
     pub name: String,
+}
+impl Unit {
+    pub fn new(name: String) -> Self {
+        Self {
+            contents: None,
+            dropins: None,
+            enabled: None,
+            mask: None,
+            name,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "systemd")]
@@ -326,4 +459,14 @@ pub struct Config {
     pub storage: Option<Storage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub systemd: Option<Systemd>,
+}
+impl Config {
+    pub fn new(ignition: Ignition) -> Self {
+        Self {
+            ignition,
+            passwd: None,
+            storage: None,
+            systemd: None,
+        }
+    }
 }

--- a/src/v3_2/mod.rs
+++ b/src/v3_2/mod.rs
@@ -15,3 +15,17 @@
 use serde::{Deserialize, Serialize};
 
 include!("schema.rs");
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            ignition: Ignition {
+                version: Some("3.2.0".into()),
+                ..Default::default()
+            },
+            passwd: None,
+            storage: None,
+            systemd: None,
+        }
+    }
+}

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -6,6 +6,11 @@ pub struct HttpHeadersItem {
     #[serde(default)]
     pub value: Option<String>,
 }
+impl HttpHeadersItem {
+    pub fn new(name: String) -> Self {
+        Self { name, value: None }
+    }
+}
 pub type HttpHeaders = Vec<HttpHeadersItem>;
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "ignition-config")]
@@ -79,6 +84,17 @@ pub struct Group {
     #[serde(default)]
     pub system: Option<bool>,
 }
+impl Group {
+    pub fn new(name: String) -> Self {
+        Self {
+            gid: None,
+            name,
+            password_hash: None,
+            should_exist: None,
+            system: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "user")]
 pub struct User {
@@ -118,6 +134,26 @@ pub struct User {
     #[serde(default)]
     pub uid: Option<i64>,
 }
+impl User {
+    pub fn new(name: String) -> Self {
+        Self {
+            gecos: None,
+            groups: None,
+            home_dir: None,
+            name,
+            no_create_home: None,
+            no_log_init: None,
+            no_user_group: None,
+            password_hash: None,
+            primary_group: None,
+            shell: None,
+            should_exist: None,
+            ssh_authorized_keys: None,
+            system: None,
+            uid: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "passwd")]
 pub struct Passwd {
@@ -152,6 +188,17 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
+impl Directory {
+    pub fn new(path: String) -> Self {
+        Self {
+            group: None,
+            mode: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
 pub struct Disk {
@@ -161,6 +208,15 @@ pub struct Disk {
     #[serde(default)]
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
+}
+impl Disk {
+    pub fn new(device: String) -> Self {
+        Self {
+            device,
+            partitions: None,
+            wipe_table: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "file")]
@@ -178,6 +234,19 @@ pub struct File {
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl File {
+    pub fn new(path: String) -> Self {
+        Self {
+            append: None,
+            contents: None,
+            group: None,
+            mode: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "filesystem")]
@@ -200,6 +269,20 @@ pub struct Filesystem {
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
 }
+impl Filesystem {
+    pub fn new(device: String) -> Self {
+        Self {
+            device,
+            format: None,
+            label: None,
+            mount_options: None,
+            options: None,
+            path: None,
+            uuid: None,
+            wipe_filesystem: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "link")]
 pub struct Link {
@@ -214,6 +297,18 @@ pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
+impl Link {
+    pub fn new(path: String, target: String) -> Self {
+        Self {
+            group: None,
+            hard: None,
+            overwrite: None,
+            path,
+            target,
+            user: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct LuksClevisCustom {
     pub config: String,
@@ -221,6 +316,15 @@ pub struct LuksClevisCustom {
     #[serde(rename = "needsNetwork")]
     pub needs_network: Option<bool>,
     pub pin: String,
+}
+impl LuksClevisCustom {
+    pub fn new(config: String, pin: String) -> Self {
+        Self {
+            config,
+            needs_network: None,
+            pin,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 pub struct LuksClevis {
@@ -255,6 +359,20 @@ pub struct Luks {
     #[serde(rename = "wipeVolume")]
     pub wipe_volume: Option<bool>,
 }
+impl Luks {
+    pub fn new(name: String) -> Self {
+        Self {
+            clevis: None,
+            device: None,
+            key_file: None,
+            label: None,
+            name,
+            options: None,
+            uuid: None,
+            wipe_volume: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 pub struct NodeGroup {
     #[serde(default)]
@@ -279,6 +397,16 @@ pub struct Node {
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl Node {
+    pub fn new(path: String) -> Self {
+        Self {
+            group: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "partition")]
@@ -318,6 +446,17 @@ pub struct Raid {
     #[serde(default)]
     pub spares: Option<i64>,
 }
+impl Raid {
+    pub fn new(devices: Vec<String>, level: String, name: String) -> Self {
+        Self {
+            devices,
+            level,
+            name,
+            options: None,
+            spares: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "tang")]
 pub struct Tang {
@@ -351,6 +490,14 @@ pub struct Dropin {
     pub contents: Option<String>,
     pub name: String,
 }
+impl Dropin {
+    pub fn new(name: String) -> Self {
+        Self {
+            contents: None,
+            name,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "unit")]
 pub struct Unit {
@@ -363,6 +510,17 @@ pub struct Unit {
     #[serde(default)]
     pub mask: Option<bool>,
     pub name: String,
+}
+impl Unit {
+    pub fn new(name: String) -> Self {
+        Self {
+            contents: None,
+            dropins: None,
+            enabled: None,
+            mask: None,
+            name,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "systemd")]
@@ -385,4 +543,14 @@ pub struct Config {
     pub storage: Option<Storage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub systemd: Option<Systemd>,
+}
+impl Config {
+    pub fn new(ignition: Ignition) -> Self {
+        Self {
+            ignition,
+            passwd: None,
+            storage: None,
+            systemd: None,
+        }
+    }
 }

--- a/src/v3_3/mod.rs
+++ b/src/v3_3/mod.rs
@@ -15,3 +15,18 @@
 use serde::{Deserialize, Serialize};
 
 include!("schema.rs");
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            ignition: Ignition {
+                version: Some("3.3.0".into()),
+                ..Default::default()
+            },
+            kernel_arguments: None,
+            passwd: None,
+            storage: None,
+            systemd: None,
+        }
+    }
+}

--- a/src/v3_3/schema.rs
+++ b/src/v3_3/schema.rs
@@ -6,6 +6,11 @@ pub struct HttpHeadersItem {
     #[serde(default)]
     pub value: Option<String>,
 }
+impl HttpHeadersItem {
+    pub fn new(name: String) -> Self {
+        Self { name, value: None }
+    }
+}
 pub type HttpHeaders = Vec<HttpHeadersItem>;
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "ignition-config")]
@@ -90,6 +95,17 @@ pub struct Group {
     #[serde(default)]
     pub system: Option<bool>,
 }
+impl Group {
+    pub fn new(name: String) -> Self {
+        Self {
+            gid: None,
+            name,
+            password_hash: None,
+            should_exist: None,
+            system: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "user")]
 pub struct User {
@@ -128,6 +144,26 @@ pub struct User {
     pub system: Option<bool>,
     #[serde(default)]
     pub uid: Option<i64>,
+}
+impl User {
+    pub fn new(name: String) -> Self {
+        Self {
+            gecos: None,
+            groups: None,
+            home_dir: None,
+            name,
+            no_create_home: None,
+            no_log_init: None,
+            no_user_group: None,
+            password_hash: None,
+            primary_group: None,
+            shell: None,
+            should_exist: None,
+            ssh_authorized_keys: None,
+            system: None,
+            uid: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "passwd")]
@@ -187,6 +223,17 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
 }
+impl Directory {
+    pub fn new(path: String) -> Self {
+        Self {
+            group: None,
+            mode: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "disk")]
 pub struct Disk {
@@ -196,6 +243,15 @@ pub struct Disk {
     #[serde(default)]
     #[serde(rename = "wipeTable")]
     pub wipe_table: Option<bool>,
+}
+impl Disk {
+    pub fn new(device: String) -> Self {
+        Self {
+            device,
+            partitions: None,
+            wipe_table: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "file")]
@@ -213,6 +269,19 @@ pub struct File {
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl File {
+    pub fn new(path: String) -> Self {
+        Self {
+            append: None,
+            contents: None,
+            group: None,
+            mode: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "filesystem")]
@@ -235,6 +304,20 @@ pub struct Filesystem {
     #[serde(rename = "wipeFilesystem")]
     pub wipe_filesystem: Option<bool>,
 }
+impl Filesystem {
+    pub fn new(device: String) -> Self {
+        Self {
+            device,
+            format: None,
+            label: None,
+            mount_options: None,
+            options: None,
+            path: None,
+            uuid: None,
+            wipe_filesystem: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "link")]
 pub struct Link {
@@ -249,6 +332,18 @@ pub struct Link {
     pub target: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl Link {
+    pub fn new(path: String) -> Self {
+        Self {
+            group: None,
+            hard: None,
+            overwrite: None,
+            path,
+            target: None,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "luks")]
@@ -270,6 +365,20 @@ pub struct Luks {
     #[serde(default)]
     #[serde(rename = "wipeVolume")]
     pub wipe_volume: Option<bool>,
+}
+impl Luks {
+    pub fn new(name: String) -> Self {
+        Self {
+            clevis: None,
+            device: None,
+            key_file: None,
+            label: None,
+            name,
+            options: None,
+            uuid: None,
+            wipe_volume: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 pub struct NodeGroup {
@@ -295,6 +404,16 @@ pub struct Node {
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<NodeUser>,
+}
+impl Node {
+    pub fn new(path: String) -> Self {
+        Self {
+            group: None,
+            overwrite: None,
+            path,
+            user: None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "partition")]
@@ -336,6 +455,17 @@ pub struct Raid {
     #[serde(default)]
     pub spares: Option<i64>,
 }
+impl Raid {
+    pub fn new(name: String) -> Self {
+        Self {
+            devices: None,
+            level: None,
+            name,
+            options: None,
+            spares: None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "tang")]
 pub struct Tang {
@@ -369,6 +499,14 @@ pub struct Dropin {
     pub contents: Option<String>,
     pub name: String,
 }
+impl Dropin {
+    pub fn new(name: String) -> Self {
+        Self {
+            contents: None,
+            name,
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "unit")]
 pub struct Unit {
@@ -381,6 +519,17 @@ pub struct Unit {
     #[serde(default)]
     pub mask: Option<bool>,
     pub name: String,
+}
+impl Unit {
+    pub fn new(name: String) -> Self {
+        Self {
+            contents: None,
+            dropins: None,
+            enabled: None,
+            mask: None,
+            name,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename = "systemd")]
@@ -406,4 +555,15 @@ pub struct Config {
     pub storage: Option<Storage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub systemd: Option<Systemd>,
+}
+impl Config {
+    pub fn new(ignition: Ignition) -> Self {
+        Self {
+            ignition,
+            kernel_arguments: None,
+            passwd: None,
+            storage: None,
+            systemd: None,
+        }
+    }
 }


### PR DESCRIPTION
Schemafy derives `Default` for structs where all fields are `Option`.  For other structs, improve ergonomics by adding a `new()` function that takes the required fields as arguments and sets everything else to `None`.

Also hand-implement `Default` for `Config`.  This avoids the need to use the awkward autogenerated `Config::new()` functions, and automatically sets `ignition.version`.