### PR TITLE
Bump clippy to 1.64.0; avoid `Eq` derive warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ env:
   # Minimum supported Rust version (MSRV)
   ACTIONS_MSRV_TOOLCHAIN: 1.49.0
   # Pinned toolchain for linting
-  ACTIONS_LINTS_TOOLCHAIN: 1.56.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.64.0
 
 jobs:
   tests-stable:

--- a/src/v3_0/mod.rs
+++ b/src/v3_0/mod.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// schemafy doesn't derive Eq on structs, and we don't do it either because
+// any floating point value added to a struct in a future schema version
+// would cause cascading Eq removals.  PartialEq is good enough for now.
+// https://github.com/Marwes/schemafy/issues/61
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 use semver::Version;
 use serde::{Deserialize, Serialize};
 

--- a/src/v3_1/mod.rs
+++ b/src/v3_1/mod.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// schemafy doesn't derive Eq on structs, and we don't do it either because
+// any floating point value added to a struct in a future schema version
+// would cause cascading Eq removals.  PartialEq is good enough for now.
+// https://github.com/Marwes/schemafy/issues/61
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 use semver::Version;
 use serde::{Deserialize, Serialize};
 

--- a/src/v3_2/mod.rs
+++ b/src/v3_2/mod.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// schemafy doesn't derive Eq on structs, and we don't do it either because
+// any floating point value added to a struct in a future schema version
+// would cause cascading Eq removals.  PartialEq is good enough for now.
+// https://github.com/Marwes/schemafy/issues/61
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 use semver::Version;
 use serde::{Deserialize, Serialize};
 

--- a/src/v3_3/mod.rs
+++ b/src/v3_3/mod.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// schemafy doesn't derive Eq on structs, and we don't do it either because
+// any floating point value added to a struct in a future schema version
+// would cause cascading Eq removals.  PartialEq is good enough for now.
+// https://github.com/Marwes/schemafy/issues/61
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 use semver::Version;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
schemafy never derives `Eq`, only `PartialEq`, and clippy now [warns](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq) about this.  If we derived `Eq` ourselves, we could end up having to remove the derive in a future schema version if a floating-point value is ever added to the spec.  We don't need `Eq` for now, so just disable the warning to keep things simple.