### PR TITLE
cargo: allow syn 2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,4 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependency
+  - skip-notes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ anyhow = "1.0"
 proc-macro2 = { version = "1.0", optional = true }
 quote = { version = "1.0", optional = true }
 schemafy_lib = { version = "0.6.0", optional = true }
-syn = { version = "1.0", features = ["full", "parsing", "visit-mut"], optional = true }
+syn = { version = ">= 1, < 3", features = ["full", "parsing", "visit-mut"], optional = true }
 tempfile = { version = "3.2.0", optional = true }
 
 [features]


### PR DESCRIPTION
Also automatically add `skip-notes` label to Dependabot bumps to match our other repos.