### PR TITLE
rust2rpm: disable development-only feature for regenerating sources

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -3,6 +3,10 @@
 ## Upcoming ignition-config 0.5.0 (unreleased)
 
 
+## ignition-config 0.4.1 (unreleased)
+
+- rust2rpm: disable development-only feature for regenerating sources
+
 
 ## ignition-config 0.4.0 (2024-05-30)
 

--- a/rust2rpm.toml
+++ b/rust2rpm.toml
@@ -1,0 +1,9 @@
+[features]
+hide = [
+    "proc-macro2",
+    "quote",
+    "schemafy_lib",
+    "syn",
+    "tempfile",
+    "regenerate"
+]


### PR DESCRIPTION
See https://src.fedoraproject.org/rpms/rust-ignition-config/pull-request/3