### PR TITLE
cargo: ignition-config release 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.75.0"
 exclude = ["/.github", "/.gitignore"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Data structures for reading/writing Ignition configs"
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
- rust2rpm: disable development-only feature for regenerating sources
- docs/release-notes: update for release 0.4.1