### PR TITLE
Remove incorrect tempfile upper bound constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,7 @@ proc-macro2 = { version = "1.0", optional = true }
 quote = { version = "1.0", optional = true }
 schemafy_lib = { version = "0.6.0", optional = true }
 syn = { version = ">= 1, < 3", features = ["full", "parsing", "visit-mut"], optional = true }
-# Pin tempfile to maintain MSRV compatibility
-# tempfile 3.25+ depends on getrandom 0.4.1+ which requires edition2024, but our MSRV is 1.75.0
-tempfile = { version = "< 3.25", optional = true }
+tempfile = { version = "3.2.0", optional = true }
 
 [features]
 regenerate = ["proc-macro2", "quote", "schemafy_lib", "syn", "tempfile"]


### PR DESCRIPTION
The constraint tempfile < 3.25 was added based on incorrect information that tempfile 3.25+ requires edition2024. In reality, tempfile 3.26.0 has an MSRV of only 1.63 and works fine with our MSRV of 1.75.0.

The upper bound prevents Fedora packaging since Fedora already has tempfile 3.25+ and cannot satisfy the < 3.25 requirement.